### PR TITLE
Allow override of erlnode start and stop wait time

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,3 +1,8 @@
+* Sat Nov 21 2015 David Hull <david.hull@openx.com> 0.6.0
+- allow override of default startup and shutdown wait time with
+  $ERLNODE_START_TIME and $ERLNODE_STOP_TIME
+- suppress crash dump from erlnodectl start and stop timeouts
+
 * Fri Nov 13 2015 Chris Varnerin <chris.varnerin@openx.com> 0.5.1
 - allow erlnode to start erlang in a cpuset
 

--- a/bin/erlnodectl
+++ b/bin/erlnodectl
@@ -43,6 +43,9 @@ node_name=`basename "$node_name_file"`
 full_name="$node_name@$hostname"
 shutdown_file=${shutdown_file-/var/run/erlang/erlnode.shutting_down}
 
+ERLSTART_START_TIME=${ERLSTART_START_TIME-100}
+ERLSTART_STOP_TIME=${ERLSTART_STOP_TIME-20}
+
 ERL_CRASH_DUMP=${ERL_CRASH_DUMP-/dev/null}
 export ERL_CRASH_DUMP
 
@@ -98,42 +101,38 @@ start () \
     "env cookie=\"$cookie\" erlstart-run-erlang \"$ERLSTART_CONFIG_FILE\""
 
   eval_with_main_node "$full_name"                                    \
-      "Wait = fun (_, 0) ->
-                    failed;
-                  (Cont, Max) ->
+      "Wait = fun (Cont) ->
                     case net_adm:ping (MainNode) of
                       pong ->
                         ok;
                       pang ->
                         timer:sleep (100),
-                        Cont (Cont, Max - 1)
+                        Cont (Cont)
                     end
               end,
-       DontTellMe = 1000,
-       ok = Wait (Wait, DontTellMe)" || {
+       timer:kill_after ($ERLSTART_START_TIME * 1000),
+       ok = Wait (Wait)" || {
     echo "" 1>&2
-    echo "$id: could not connect to node after 100 seconds" 1>&2
+    echo "$id: could not connect to node after $ERLSTART_START_TIME seconds" 1>&2
     exit 1
   }
 
   eval_with_main_node "$full_name"                                    \
-      "Wait = fun (_, 0) ->
-                    failed;
-                  (Cont, Max) ->
+      "Wait = fun (Cont) ->
                     case rpc:call (MainNode, init, get_status, []) of
                       { started, _ } ->
                         ok;
                       { starting, _ } ->
                         timer:sleep (100),
-                        Cont (Cont, Max - 1);
+                        Cont (Cont);
                       { Status, _ } ->
                         { failed, Status }
                     end
               end,
-       DontTellMe = 1000,
-       ok = Wait (Wait, DontTellMe)" || {
+       timer:kill_after ($ERLSTART_START_TIME * 1000),
+       ok = Wait (Wait)" || {
     echo "" 1>&2
-    echo "$id: node did not boot after 100 seconds" 1>&2
+    echo "$id: node did not boot after $ERLSTART_START_TIME seconds" 1>&2
     exit 1
   }
 
@@ -163,21 +162,19 @@ stop () \
   erlstart-eval 'init:stop ()' >/dev/null 2>/dev/null
 
   eval_with_main_node "$full_name"                                    \
-      "Wait = fun (_, 0) ->
-                    failed;
-                  (Cont, Max) ->
+      "Wait = fun (Cont) ->
                     case net_adm:ping (MainNode) of
                       pong ->
                         timer:sleep (100),
-                        Cont (Cont, Max - 1);
+                        Cont (Cont);
                       pang ->
                         ok
                     end
               end,
-       DontTellMe = 1000,
-       ok = Wait (Wait, DontTellMe)" || {
+       timer:kill_after ($ERLSTART_START_TIME * 1000),
+       ok = Wait (Wait)" || {
     echo "" 1>&2
-    echo "$id: node still responsive after 100 seconds" 1>&2
+    echo "$id: node still responsive after $ERLSTART_STOP_TIME seconds" 1>&2
     exit 1
   }
 

--- a/bin/erlnodectl
+++ b/bin/erlnodectl
@@ -100,6 +100,9 @@ start () \
   su >/dev/null $csetsep -l $dashs "$user" -c                         \
     "env cookie=\"$cookie\" erlstart-run-erlang \"$ERLSTART_CONFIG_FILE\""
 
+  ERL_CRASH_DUMP=/dev/null; export ERL_CRASH_DUMP
+  ERL_CRASH_DUMP_SECONDS=0; export ERL_CRASH_DUMP_SECONDS
+
   eval_with_main_node "$full_name"                                    \
       "Wait = fun (Cont) ->
                     case net_adm:ping (MainNode) of
@@ -144,6 +147,9 @@ stop () \
   test "`id -u`" -eq 0 || exec sudo $0 "$@"
 
   printf "Stopping Erlang... "
+
+  ERL_CRASH_DUMP=/dev/null; export ERL_CRASH_DUMP
+  ERL_CRASH_DUMP_SECONDS=0; export ERL_CRASH_DUMP_SECONDS
 
   if test ! -f "$node_name_file" ||                                   \
      test true != "`erlstart-eval 'true' 2>/dev/null`" 2>/dev/null

--- a/fw-pkgin/config
+++ b/fw-pkgin/config
@@ -2,7 +2,7 @@
 # variable FW_PACKAGE_DEFAULT_MAINTAINER if non-empty at init time
 
 FW_PACKAGE_NAME="erlnode"
-FW_PACKAGE_VERSION="0.5.1"
+FW_PACKAGE_VERSION="0.6.0"
 FW_PACKAGE_MAINTAINER="Anthony Molinaro <anthonym@alumni.caltech.edu>"
 FW_PACKAGE_SHORT_DESCRIPTION="An Erlang Node with ErlRc Integration."
 FW_PACKAGE_DESCRIPTION=`cat README`


### PR DESCRIPTION
Allow override of erlnodectl start or stop wait time by setting $ERLSTART_START_TIME or $ERLSTART_STOP_TIME. As part of this, I rewrote the code to use `timer:kill_after/1` instead of counting the number of sleeps.

Attempt to avoid writing a crash dump file when the start or stop exceeds the wait time.
